### PR TITLE
Order comments by created time

### DIFF
--- a/apps/front/modules/default/actions/commentGlobalComponent.class.php
+++ b/apps/front/modules/default/actions/commentGlobalComponent.class.php
@@ -33,6 +33,7 @@ class commentGlobalComponent extends sfComponent
           ->filterByType($this->type)
           ->filterByBranchId($this->id)
           ->leftJoin('sfGuardUserRelatedByUserId')
+          ->orderByCreatedAt()
           ->find()
         ;
         break;
@@ -50,6 +51,7 @@ class commentGlobalComponent extends sfComponent
           ->filterByType($this->type)
           ->filterByFileId($this->id)
           ->leftJoin('sfGuardUserRelatedByUserId')
+          ->orderByCreatedAt()
           ->find()
         ;
         break;


### PR DESCRIPTION
Fix the ordering of comments to be sorted by created times to make replies easier to follow.